### PR TITLE
first step to element amalgamation in openmc.

### DIFF
--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3186,13 +3186,13 @@ void LibMesh::set_score_data(const std::string& var_name,
         auto bin = get_bin_from_element(*_neighbour);
         // set value
         vector<libMesh::dof_id_type> value_dof_indices;
-        dof_map.dof_indices(*it, value_dof_indices, value_num);
+        dof_map.dof_indices(_neighbor, value_dof_indices, value_num);
         Ensures(value_dof_indices.size() == 1);
         eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
 
         // set std dev
         vector<libMesh::dof_id_type> std_dev_dof_indices;E
-        dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
+        dof_map.dof_indices(_neighbor, std_dev_dof_indices, std_dev_num);
         Ensures(std_dev_dof_indices.size() == 1);
         eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
       }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3176,9 +3176,10 @@ void LibMesh::set_score_data(const std::string& var_name,
   // look up the std dev variable
   std::string std_dev_name = var_name + "_std_dev";
   unsigned int std_dev_num = variable_map_.at(std_dev_name);
-   for (auto it = m_->local_elements_begin(); it != m_->local_elements_end();
-       it++) {
-  if (it->refinement_flag()!=Elem::AMALGAMATE){
+
+  for (auto it = m_->local_elements_begin(); it != m_->local_elements_end(); it++) {
+
+  if (it->refinement_flag()!=Elem::AMALGAMATE && !(!(*it)->active())){
     for (unsigned_int side = 0; side < it->n_sides(); ++side) {
       const libMesh::Elem* neighbor = it->neighbor_ptr(side);
       auto bin = get_bin_from_element(*_neighbour);
@@ -3189,7 +3190,7 @@ void LibMesh::set_score_data(const std::string& var_name,
       eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
 
       // set std dev
-      vector<libMesh::dof_id_type> std_dev_dof_indices;
+      vector<libMesh::dof_id_type> std_dev_dof_indices;E
       dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
       Ensures(std_dev_dof_indices.size() == 1);
       eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
@@ -3197,18 +3198,20 @@ void LibMesh::set_score_data(const std::string& var_name,
   }
 
 
-  auto bin = get_bin_from_element(*it);
-  // set value
-  vector<libMesh::dof_id_type> value_dof_indices;
-  dof_map.dof_indices(*it, value_dof_indices, value_num);
-  Ensures(value_dof_indices.size() == 1);
-  eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
+  if (!(*it)->active()){
+    auto bin = get_bin_from_element(*it);
+    // set value
+    vector<libMesh::dof_id_type> value_dof_indices;
+    dof_map.dof_indices(*it, value_dof_indices, value_num);
+    Ensures(value_dof_indices.size() == 1);
+    eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
 
-  // set std dev
-  vector<libMesh::dof_id_type> std_dev_dof_indices;
-  dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
-  Ensures(std_dev_dof_indices.size() == 1);
-  eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
+    // set std dev
+    vector<libMesh::dof_id_type> std_dev_dof_indices;
+    dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
+    Ensures(std_dev_dof_indices.size() == 1);
+    eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
+  }
 
   }
 }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3176,26 +3176,40 @@ void LibMesh::set_score_data(const std::string& var_name,
   // look up the std dev variable
   std::string std_dev_name = var_name + "_std_dev";
   unsigned int std_dev_num = variable_map_.at(std_dev_name);
-
-  for (auto it = m_->local_elements_begin(); it != m_->local_elements_end();
+   for (auto it = m_->local_elements_begin(); it != m_->local_elements_end();
        it++) {
-    if (!(*it)->active()) {
-      continue;
+  if (it->refinement_flag()!=Elem::AMALGAMATE){
+    for (unsigned_int side = 0; side < it->n_sides(); ++side) {
+      const libMesh::Elem* neighbor = it->neighbor_ptr(side);
+      auto bin = get_bin_from_element(*_neighbour);
+      // set value
+      vector<libMesh::dof_id_type> value_dof_indices;
+      dof_map.dof_indices(*it, value_dof_indices, value_num);
+      Ensures(value_dof_indices.size() == 1);
+      eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
+
+      // set std dev
+      vector<libMesh::dof_id_type> std_dev_dof_indices;
+      dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
+      Ensures(std_dev_dof_indices.size() == 1);
+      eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
     }
+  }
 
-    auto bin = get_bin_from_element(*it);
 
-    // set value
-    vector<libMesh::dof_id_type> value_dof_indices;
-    dof_map.dof_indices(*it, value_dof_indices, value_num);
-    Ensures(value_dof_indices.size() == 1);
-    eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
+  auto bin = get_bin_from_element(*it);
+  // set value
+  vector<libMesh::dof_id_type> value_dof_indices;
+  dof_map.dof_indices(*it, value_dof_indices, value_num);
+  Ensures(value_dof_indices.size() == 1);
+  eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
 
-    // set std dev
-    vector<libMesh::dof_id_type> std_dev_dof_indices;
-    dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
-    Ensures(std_dev_dof_indices.size() == 1);
-    eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
+  // set std dev
+  vector<libMesh::dof_id_type> std_dev_dof_indices;
+  dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
+  Ensures(std_dev_dof_indices.size() == 1);
+  eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
+
   }
 }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3179,21 +3179,23 @@ void LibMesh::set_score_data(const std::string& var_name,
 
   for (auto it = m_->local_elements_begin(); it != m_->local_elements_end(); it++) {
 
-  if (it->refinement_flag()==Elem::AMALGAMATE && ((*it)->active())){
-    for (unsigned_int side = 0; side < it->n_sides(); ++side) {
-      const libMesh::Elem* neighbor = it->neighbor_ptr(side);
-      auto bin = get_bin_from_element(*_neighbour);
-      // set value
-      vector<libMesh::dof_id_type> value_dof_indices;
-      dof_map.dof_indices(*it, value_dof_indices, value_num);
-      Ensures(value_dof_indices.size() == 1);
-      eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
+  if (*it->refinement_flag()==Elem::AMALGAMATE && ((*it)->active())){
+    for (unsigned int side = 0; side < *it->n_sides(); ++side) {
+      const libMesh::Elem* _neighbor = *it->neighbor_ptr(side);
+      if (_neighbor) {
+        auto bin = get_bin_from_element(*_neighbour);
+        // set value
+        vector<libMesh::dof_id_type> value_dof_indices;
+        dof_map.dof_indices(*it, value_dof_indices, value_num);
+        Ensures(value_dof_indices.size() == 1);
+        eqn_sys.solution->set(value_dof_indices[0], values.at(bin));
 
-      // set std dev
-      vector<libMesh::dof_id_type> std_dev_dof_indices;E
-      dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
-      Ensures(std_dev_dof_indices.size() == 1);
-      eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
+        // set std dev
+        vector<libMesh::dof_id_type> std_dev_dof_indices;E
+        dof_map.dof_indices(*it, std_dev_dof_indices, std_dev_num);
+        Ensures(std_dev_dof_indices.size() == 1);
+        eqn_sys.solution->set(std_dev_dof_indices[0], std_dev.at(bin));
+      }
     }
   }
 

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3179,7 +3179,7 @@ void LibMesh::set_score_data(const std::string& var_name,
 
   for (auto it = m_->local_elements_begin(); it != m_->local_elements_end(); it++) {
 
-  if (it->refinement_flag()!=Elem::AMALGAMATE && (!(*it)->active())){
+  if (it->refinement_flag()==Elem::AMALGAMATE && ((*it)->active())){
     for (unsigned_int side = 0; side < it->n_sides(); ++side) {
       const libMesh::Elem* neighbor = it->neighbor_ptr(side);
       auto bin = get_bin_from_element(*_neighbour);
@@ -3198,7 +3198,7 @@ void LibMesh::set_score_data(const std::string& var_name,
   }
 
 
-  if (!(*it)->active()){
+  if ((*it)->active()){
     auto bin = get_bin_from_element(*it);
     // set value
     vector<libMesh::dof_id_type> value_dof_indices;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3179,7 +3179,7 @@ void LibMesh::set_score_data(const std::string& var_name,
 
   for (auto it = m_->local_elements_begin(); it != m_->local_elements_end(); it++) {
 
-  if (it->refinement_flag()!=Elem::AMALGAMATE && !(!(*it)->active())){
+  if (it->refinement_flag()!=Elem::AMALGAMATE && (!(*it)->active())){
     for (unsigned_int side = 0; side < it->n_sides(); ++side) {
       const libMesh::Elem* neighbor = it->neighbor_ptr(side);
       auto bin = get_bin_from_element(*_neighbour);


### PR DESCRIPTION
If an element is marked for AMALGAMATION `set_score_data `should tally on it's neighbours as well. (Haven't come up yet neighbour selection algorithm.)

Issues:
1. Could end up doing tallying on the same element multiple times if two `AMALGAMTE`d meshes are neighbours
2. Refinement flags needs to be cleared after openmc completes tallying ( https://github.com/magnoxemo/libmesh/blob/4e0d14ceacac702abf2d09c6b31a9a53b7e15f69/src/mesh/mesh_refinement_flagging.C )

```
void MeshRefinement::clean_refinement_flags ()
{
  // Possibly clean up the refinement flags from
  // a previous step
  for (auto & elem : _mesh.element_ptr_range())
    {
      if (elem->active())
        {
          if (elem->refinement_flag()!=Elem::AMALGAMATE)
          {
            elem->set_refinement_flag(Elem::DO_NOTHING);
            elem->set_p_refinement_flag(Elem::DO_NOTHING);
          }
        }
      else
        {
          elem->set_refinement_flag(Elem::INACTIVE);
          elem->set_p_refinement_flag(Elem::INACTIVE);
        }
    }
}
``` 
This might not be necessary. 

The another thing I was thinking about adding another dof `element_age` for the clustering turned out not necessary. Possible solution to that maybe use the `cluster ID` or `extra_element_integer` (invokes some memory management question) feature implemented in libmesh. https://github.com/libMesh/libmesh/blob/acaf7757ac14fc98411cfc08a209218599db769e/src/mesh/mesh_base.C#L565  

https://mooseframework.inl.gov/docs/doxygen/libmesh/classlibMesh_1_1DofObject.html#ae3ad33fd55ef000261bf20ff77100049 


(It doesn't work but making changes so that I can share my idea with @gonuke and receive his suggestion)