### PR TITLE
adding the base structure for on the fly amalgamation

### DIFF
--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -946,7 +946,7 @@ public:
   LibMesh(pugi::xml_node node);
   LibMesh(const std::string& filename, double length_multiplier = 1.0);
   LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
-  LibMesh(libMesh::MeshBase& input_mesh,const std::string& extra_element_integer_name, double length_multiplier = 1.0);
+  LibMesh(libMesh::MeshBase& input_mesh,const std::string& cluster_element_integer_name, double length_multiplier = 1.0);
 
   static const std::string mesh_lib_type;
 

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -1032,8 +1032,9 @@ private:
   std::vector<int> elem_to_bin_map_; //!< mapping dof indices to bin indices for
                                      //!< active elements
 
-  int extra_element_integer_index_ = -1 ;
-  bool mesh_tally_amalgamation_valid_ = false ;
+  int extra_element_integer_index_ = -1 ; //!< extra element interger index for element clustering
+  bool amalgamation_ = false ; //!< whether we are doing mesh and tally amalgamation
+                               //!< by default it's turned off.
 
   /*create a hash map where every element in a cluster would map to the first element of in that cluster
    * if the element isn't part of a cluster then it will point to it self

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -1032,10 +1032,10 @@ private:
   std::vector<int> elem_to_bin_map_; //!< mapping dof indices to bin indices for
                                      //!< active elements
 
-  int extra_element_integer_index_ = -1 ; //!< extra element interger index for element clustering
   bool amalgamation_ = false ; //!< whether we are doing mesh and tally amalgamation
                                //!< by default it's turned off.
 
+  int cluster_element_integer_index_ = -1 ; //!< extra element integer index for element clustering
   /*create a hash map where every element in a cluster would map to the first element of in that cluster
    * if the element isn't part of a cluster then it will point to it self
    * <any_element_in_a_cluster, first element in that cluster >

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -1034,6 +1034,13 @@ private:
 
   int extra_element_integer_index_ = -1 ;
   bool mesh_tally_amalgamation_valid_ = false ;
+
+  /*create a hash map where every element in a cluster would map to the first element of in that cluster
+   * if the element isn't part of a cluster then it will point to it self
+   * <any_element_in_a_cluster, first element in that cluster >
+   */
+  std::unordered_map<const libMesh::Elem*, const libMesh::Elem*> clustering_element_mapping_;
+
 };
 
 #endif

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -946,6 +946,7 @@ public:
   LibMesh(pugi::xml_node node);
   LibMesh(const std::string& filename, double length_multiplier = 1.0);
   LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
+  LibMesh(libMesh::MeshBase& input_mesh,const std::string& extra_element_integer_name, double length_multiplier = 1.0);
 
   static const std::string mesh_lib_type;
 
@@ -1030,6 +1031,9 @@ private:
                       //!< elements
   std::vector<int> elem_to_bin_map_; //!< mapping dof indices to bin indices for
                                      //!< active elements
+
+  int extra_element_integer_index_ = -1 ;
+  bool mesh_tally_amalgamation_valid_ = false ;
 };
 
 #endif

--- a/include/openmc/mesh.h
+++ b/include/openmc/mesh.h
@@ -946,7 +946,6 @@ public:
   LibMesh(pugi::xml_node node);
   LibMesh(const std::string& filename, double length_multiplier = 1.0);
   LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier = 1.0);
-  LibMesh(libMesh::MeshBase& input_mesh,const std::string& cluster_element_integer_name, double length_multiplier = 1.0);
 
   static const std::string mesh_lib_type;
 
@@ -991,6 +990,10 @@ public:
   double volume(int bin) const override;
 
   libMesh::MeshBase* mesh_ptr() const { return m_; };
+
+
+  //!setter for mesh tally amalgamtion
+  void set_mesh_tally_amalgamation(std::string cluster_element_integer_name);
 
 private:
   void initialize() override;

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3254,7 +3254,7 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh,
     input_mesh.has_elem_integer(extra_element_integer_name)
       ? input_mesh.get_elem_integer_index(extra_element_integer_name)
       : -1;
-  mesh_tally_amalgamation_valid_ = (extra_element_integer_index_ == -1) ? false : true;
+  amalgamation_ = (extra_element_integer_index_ != -1);
 
   initialize();
 }
@@ -3327,54 +3327,30 @@ void LibMesh::initialize()
   // contiguous in ID space, so we need to map from bin indices (defined over
   // active elements) to global dof ids
   if (adaptive_) {
-    //std::cout<<"maping eveything again\n";
     bin_to_elem_map_.reserve(m_->n_active_elem());
     elem_to_bin_map_.resize(m_->n_elem(), -1);
 
-    //clear the previous history
-    clustering_element_mapping_.clear();
+    //reseve the hash map for cluster elements
+    clustering_element_mapping_.reserve(m_->n_active_elem());
 
     //adding clustering map
     for (auto it = m_->active_elements_begin(); it != m_->active_elements_end();
       it++) {
       auto elem = *it;
 
-      if (elem->get_extra_integer(extra_element_integer_index_)!=-1 and mesh_tally_amalgamation_valid_) {
-        //get the first element
-        auto first_element_in_a_cluster = m_->elem_ptr(elem->get_extra_integer(extra_element_integer_index_));
-        if (first_element_in_a_cluster->active() and first_element_in_a_cluster)
-          clustering_element_mapping_.insert(std::make_pair(elem, first_element_in_a_cluster));
-        else
-          clustering_element_mapping_.insert(std::make_pair(elem, elem));
+      if (amalgamation_) {
+        auto cluster_elem = elem;
+        unsigned int cluster_id = elem->get_extra_integer(extra_element_integer_index_);
+        if (cluster_id != -1) {
+          auto first_element_in_a_cluster = m_->elem_ptr(cluster_id);
+          if (first_element_in_a_cluster and first_element_in_a_cluster->active())
+            cluster_elem = first_element_in_a_cluster;
+        }
+        clustering_element_mapping_.insert(std::make_pair(elem, cluster_elem));
       }
-      else{
-        clustering_element_mapping_.insert(std::make_pair(elem,elem));
-      }
+
       bin_to_elem_map_.push_back(elem->id());
       elem_to_bin_map_[elem->id()] = bin_to_elem_map_.size() - 1;
-    }
-  }
-  else{
-    //std::cout<<"maping eveything with no adaptivity \n";
-    //clear the previous history
-    clustering_element_mapping_.clear();
-
-    //adding clustering map
-    for (auto it = m_->active_elements_begin(); it != m_->active_elements_end();
-      it++) {
-      auto elem = *it;
-
-      if (elem->get_extra_integer(extra_element_integer_index_)!=-1 and mesh_tally_amalgamation_valid_) {
-        auto first_element_in_a_cluster = m_->elem_ptr(elem->get_extra_integer(extra_element_integer_index_));
-
-        if (first_element_in_a_cluster->active() and first_element_in_a_cluster)
-          clustering_element_mapping_.insert(std::make_pair(elem, first_element_in_a_cluster));
-        else
-          clustering_element_mapping_.insert(std::make_pair(elem, elem));
-      }
-      else
-        clustering_element_mapping_.insert(std::make_pair(elem,elem));
-
     }
   }
 
@@ -3586,15 +3562,15 @@ int LibMesh::get_bin(Position r) const
   }
 
   const auto& point_locator = pl_.at(thread_num());
-  const auto element = (*point_locator)(p);
 
-  return element? get_bin_from_element(clustering_element_mapping_.at(element)):-1;
+  const auto elem_ptr = (*point_locator)(p);
+  return elem_ptr ? get_bin_from_element(elem_ptr) : -1;
 }
 
 int LibMesh::get_bin_from_element(const libMesh::Elem* elem) const
 {
   int bin =
-    adaptive_ ? elem_to_bin_map_[elem->id()] : elem->id() - first_element_id_;
+    adaptive_ ? elem_to_bin_map_[clustering_element_mapping_.at(elem)->id()] : elem->id() - first_element_id_;
   if (bin >= n_bins() || bin < 0) {
     fatal_error(fmt::format("Invalid bin: {}", bin));
   }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3239,11 +3239,12 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
 }
 
 
-void LibMesh::set_mesh_tally_amalgamation(std::string cluster_element_integer_name){
+void
+LibMesh::set_mesh_tally_amalgamation(std::string cluster_element_integer_name){
 
-  cluster_element_integer_index_ = input_mesh.has_elem_integer(cluster_element_integer_name)
-      ? input_mesh.get_elem_integer_index(cluster_element_integer_name)
-      : -1;
+  cluster_element_integer_index_ = m_->has_elem_integer(cluster_element_integer_name)
+                                     ? m_->get_elem_integer_index(cluster_element_integer_name)
+                                     : -1;
   amalgamation_ = (cluster_element_integer_index_ != -1);
 
   //should we add a warning if amalgamation is false?
@@ -3256,7 +3257,8 @@ void LibMesh::set_mesh_tally_amalgamation(std::string cluster_element_integer_na
     //adding clustering map
     for (auto it = m_->active_elements_begin(); it != m_->active_elements_end(); it++) {
 
-      auto cluster_elem = *it;
+      auto elem = *it;
+      auto cluster_elem = elem;
       unsigned int  cluster_id = elem->get_extra_integer(cluster_element_integer_index_);
 
       if (cluster_id != -1) {
@@ -3302,7 +3304,6 @@ void LibMesh::build_eqn_sys()
 
 // intialize from mesh file
 void LibMesh::initialize()
-  void LibMesh::initialize()
 {
   if (!settings::libmesh_comm) {
     fatal_error("Attempting to use an unstructured mesh without a libMesh "

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3240,15 +3240,23 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
 
 LibMesh::LibMesh(libMesh::MeshBase& input_mesh,
   const std::string& extra_element_integer_name, double length_multiplier)
-  : LibMesh::LibMesh(input_mesh, length_multiplier)
+  : adaptive_(input_mesh.n_active_elem() != input_mesh.n_elem())
 {
+  if (!dynamic_cast<libMesh::ReplicatedMesh*>(&input_mesh)) {
+    fatal_error("At present LibMesh tallies require a replicated mesh. Please "
+                "ensure 'input_mesh' is a libMesh::ReplicatedMesh.");
+  }
+
+  m_ = &input_mesh;
+  set_length_multiplier(length_multiplier);
 
   extra_element_integer_index_ =
     input_mesh.has_elem_integer(extra_element_integer_name)
       ? input_mesh.get_elem_integer_index(extra_element_integer_name)
       : -1;
-  mesh_tally_amalgamation_valid_ =
-    extra_element_integer_index_ == -1 ? false : true;
+  mesh_tally_amalgamation_valid_ = (extra_element_integer_index_ == -1) ? false : true;
+
+  initialize();
 }
 
 // create the mesh from an input file
@@ -3319,14 +3327,54 @@ void LibMesh::initialize()
   // contiguous in ID space, so we need to map from bin indices (defined over
   // active elements) to global dof ids
   if (adaptive_) {
+    //std::cout<<"maping eveything again\n";
     bin_to_elem_map_.reserve(m_->n_active_elem());
     elem_to_bin_map_.resize(m_->n_elem(), -1);
+
+    //clear the previous history
+    clustering_element_mapping_.clear();
+
+    //adding clustering map
     for (auto it = m_->active_elements_begin(); it != m_->active_elements_end();
-         it++) {
+      it++) {
       auto elem = *it;
 
+      if (elem->get_extra_integer(extra_element_integer_index_)!=-1 and mesh_tally_amalgamation_valid_) {
+        //get the first element
+        auto first_element_in_a_cluster = m_->elem_ptr(elem->get_extra_integer(extra_element_integer_index_));
+        if (first_element_in_a_cluster->active() and first_element_in_a_cluster)
+          clustering_element_mapping_.insert(std::make_pair(elem, first_element_in_a_cluster));
+        else
+          clustering_element_mapping_.insert(std::make_pair(elem, elem));
+      }
+      else{
+        clustering_element_mapping_.insert(std::make_pair(elem,elem));
+      }
       bin_to_elem_map_.push_back(elem->id());
       elem_to_bin_map_[elem->id()] = bin_to_elem_map_.size() - 1;
+    }
+  }
+  else{
+    //std::cout<<"maping eveything with no adaptivity \n";
+    //clear the previous history
+    clustering_element_mapping_.clear();
+
+    //adding clustering map
+    for (auto it = m_->active_elements_begin(); it != m_->active_elements_end();
+      it++) {
+      auto elem = *it;
+
+      if (elem->get_extra_integer(extra_element_integer_index_)!=-1 and mesh_tally_amalgamation_valid_) {
+        auto first_element_in_a_cluster = m_->elem_ptr(elem->get_extra_integer(extra_element_integer_index_));
+
+        if (first_element_in_a_cluster->active() and first_element_in_a_cluster)
+          clustering_element_mapping_.insert(std::make_pair(elem, first_element_in_a_cluster));
+        else
+          clustering_element_mapping_.insert(std::make_pair(elem, elem));
+      }
+      else
+        clustering_element_mapping_.insert(std::make_pair(elem,elem));
+
     }
   }
 
@@ -3481,7 +3529,7 @@ void LibMesh::set_score_data(const std::string& var_name,
   unsigned int std_dev_num = variable_map_.at(std_dev_name);
 
   for (auto it = m_->local_elements_begin(); it != m_->local_elements_end();
-       it++) {
+    it++) {
     if (!(*it)->active()) {
       continue;
     }
@@ -3538,21 +3586,9 @@ int LibMesh::get_bin(Position r) const
   }
 
   const auto& point_locator = pl_.at(thread_num());
-
   const auto element = (*point_locator)(p);
-  if (element) {
-    if (mesh_tally_amalgamation_valid_) {
-      if (element->get_extra_integer(extra_element_integer_index_) != -1) {
-        // that means part of a cluster. Now return the first element in the
-        // cluster
-        auto first_element = mesh_ptr()->elem_ptr(
-          element->get_extra_integer(extra_element_integer_index_));
-        return first_element ? get_bin_from_element(first_element) : -1;
-      }
-    }
-    return get_bin_from_element(element);
-  }
-  return -1;
+
+  return element? get_bin_from_element(clustering_element_mapping_.at(element)):-1;
 }
 
 int LibMesh::get_bin_from_element(const libMesh::Elem* elem) const

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3239,7 +3239,7 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
 }
 
 LibMesh::LibMesh(libMesh::MeshBase& input_mesh,
-  const std::string& extra_element_integer_name, double length_multiplier)
+  const std::string& cluster_element_integer_name, double length_multiplier)
   : adaptive_(input_mesh.n_active_elem() != input_mesh.n_elem())
 {
   if (!dynamic_cast<libMesh::ReplicatedMesh*>(&input_mesh)) {
@@ -3251,8 +3251,8 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh,
   set_length_multiplier(length_multiplier);
 
   cluster_element_integer_index_ =
-    input_mesh.has_elem_integer(extra_element_integer_name)
-      ? input_mesh.get_elem_integer_index(extra_element_integer_name)
+    input_mesh.has_elem_integer(cluster_element_integer_name)
+      ? input_mesh.get_elem_integer_index(cluster_element_integer_name)
       : -1;
   amalgamation_ = (cluster_element_integer_index_ != -1);
 
@@ -3340,7 +3340,7 @@ void LibMesh::initialize()
 
       if (amalgamation_) {
         auto cluster_elem = elem;
-        unsigned int  p = elem->get_extra_integer(cluster_element_integer_index_);
+        unsigned int  cluster_id = elem->get_extra_integer(cluster_element_integer_index_);
         if (cluster_id != -1) {
           auto first_element_in_a_cluster = m_->elem_ptr(cluster_id);
           if (first_element_in_a_cluster and first_element_in_a_cluster->active())

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3249,7 +3249,7 @@ LibMesh::set_mesh_tally_amalgamation(std::string cluster_element_integer_name){
 
   //should we add a warning if amalgamation is false?
 
-  if (adaptive_ && amalgamation_) {
+  if (amalgamation_) {
 
     //reseve the hash map for cluster elements
     clustering_element_mapping_.reserve(m_->n_active_elem());

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3569,8 +3569,9 @@ int LibMesh::get_bin(Position r) const
 
 int LibMesh::get_bin_from_element(const libMesh::Elem* elem) const
 {
-  int bin =
-    adaptive_ ? elem_to_bin_map_[clustering_element_mapping_.at(elem)->id()] : elem->id() - first_element_id_;
+  auto tally_elem = amalgamation_ ? clustering_element_mapping_.at(elem) : elem;
+  int bin = adaptive_ ? elem_to_bin_map_[tally_elem->id()] : tally_elem->id() - first_element_id_;
+
   if (bin >= n_bins() || bin < 0) {
     fatal_error(fmt::format("Invalid bin: {}", bin));
   }

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3250,11 +3250,11 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh,
   m_ = &input_mesh;
   set_length_multiplier(length_multiplier);
 
-  extra_element_integer_index_ =
+  cluster_element_integer_index_ =
     input_mesh.has_elem_integer(extra_element_integer_name)
       ? input_mesh.get_elem_integer_index(extra_element_integer_name)
       : -1;
-  amalgamation_ = (extra_element_integer_index_ != -1);
+  amalgamation_ = (cluster_element_integer_index_ != -1);
 
   initialize();
 }
@@ -3340,7 +3340,7 @@ void LibMesh::initialize()
 
       if (amalgamation_) {
         auto cluster_elem = elem;
-        unsigned int cluster_id = elem->get_extra_integer(extra_element_integer_index_);
+        unsigned int cluster_id = elem->get_extra_integer(cluster_element_integer_index_);
         if (cluster_id != -1) {
           auto first_element_in_a_cluster = m_->elem_ptr(cluster_id);
           if (first_element_in_a_cluster and first_element_in_a_cluster->active())

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3340,7 +3340,7 @@ void LibMesh::initialize()
 
       if (amalgamation_) {
         auto cluster_elem = elem;
-        unsigned int cluster_id = elem->get_extra_integer(cluster_element_integer_index_);
+        unsigned int  p = elem->get_extra_integer(cluster_element_integer_index_);
         if (cluster_id != -1) {
           auto first_element_in_a_cluster = m_->elem_ptr(cluster_id);
           if (first_element_in_a_cluster and first_element_in_a_cluster->active())

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3238,25 +3238,39 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
   initialize();
 }
 
-LibMesh::LibMesh(libMesh::MeshBase& input_mesh,
-  const std::string& cluster_element_integer_name, double length_multiplier)
-  : adaptive_(input_mesh.n_active_elem() != input_mesh.n_elem())
-{
-  if (!dynamic_cast<libMesh::ReplicatedMesh*>(&input_mesh)) {
-    fatal_error("At present LibMesh tallies require a replicated mesh. Please "
-                "ensure 'input_mesh' is a libMesh::ReplicatedMesh.");
-  }
 
-  m_ = &input_mesh;
-  set_length_multiplier(length_multiplier);
+void LibMesh::set_mesh_tally_amalgamation(std::string cluster_element_integer_name){
 
-  cluster_element_integer_index_ =
-    input_mesh.has_elem_integer(cluster_element_integer_name)
+  cluster_element_integer_index_ = input_mesh.has_elem_integer(cluster_element_integer_name)
       ? input_mesh.get_elem_integer_index(cluster_element_integer_name)
       : -1;
   amalgamation_ = (cluster_element_integer_index_ != -1);
 
-  initialize();
+  //should we add a warning if amalgamation is false?
+
+  if (adaptive_ && amalgamation_) {
+
+    //reseve the hash map for cluster elements
+    clustering_element_mapping_.reserve(m_->n_active_elem());
+
+    //adding clustering map
+    for (auto it = m_->active_elements_begin(); it != m_->active_elements_end(); it++) {
+
+      auto cluster_elem = *it;
+      unsigned int  cluster_id = elem->get_extra_integer(cluster_element_integer_index_);
+
+      if (cluster_id != -1) {
+        auto first_element_in_a_cluster = m_->elem_ptr(cluster_id);
+
+        if (first_element_in_a_cluster and first_element_in_a_cluster->active())
+          cluster_elem = first_element_in_a_cluster;
+      }
+      clustering_element_mapping_.insert(std::make_pair(elem, cluster_elem));
+
+    }
+  }
+
+
 }
 
 // create the mesh from an input file
@@ -3288,6 +3302,7 @@ void LibMesh::build_eqn_sys()
 
 // intialize from mesh file
 void LibMesh::initialize()
+  void LibMesh::initialize()
 {
   if (!settings::libmesh_comm) {
     fatal_error("Attempting to use an unstructured mesh without a libMesh "
@@ -3329,25 +3344,9 @@ void LibMesh::initialize()
   if (adaptive_) {
     bin_to_elem_map_.reserve(m_->n_active_elem());
     elem_to_bin_map_.resize(m_->n_elem(), -1);
-
-    //reseve the hash map for cluster elements
-    clustering_element_mapping_.reserve(m_->n_active_elem());
-
-    //adding clustering map
     for (auto it = m_->active_elements_begin(); it != m_->active_elements_end();
       it++) {
       auto elem = *it;
-
-      if (amalgamation_) {
-        auto cluster_elem = elem;
-        unsigned int  cluster_id = elem->get_extra_integer(cluster_element_integer_index_);
-        if (cluster_id != -1) {
-          auto first_element_in_a_cluster = m_->elem_ptr(cluster_id);
-          if (first_element_in_a_cluster and first_element_in_a_cluster->active())
-            cluster_elem = first_element_in_a_cluster;
-        }
-        clustering_element_mapping_.insert(std::make_pair(elem, cluster_elem));
-      }
 
       bin_to_elem_map_.push_back(elem->id());
       elem_to_bin_map_[elem->id()] = bin_to_elem_map_.size() - 1;
@@ -3361,6 +3360,7 @@ void LibMesh::initialize()
   lower_left_ = {ll(0), ll(1), ll(2)};
   upper_right_ = {ur(0), ur(1), ur(2)};
 }
+
 
 // Sample position within a tet for LibMesh type tets
 Position LibMesh::sample_element(int32_t bin, uint64_t* seed) const

--- a/src/mesh.cpp
+++ b/src/mesh.cpp
@@ -3238,6 +3238,19 @@ LibMesh::LibMesh(libMesh::MeshBase& input_mesh, double length_multiplier)
   initialize();
 }
 
+LibMesh::LibMesh(libMesh::MeshBase& input_mesh,
+  const std::string& extra_element_integer_name, double length_multiplier)
+  : LibMesh::LibMesh(input_mesh, length_multiplier)
+{
+
+  extra_element_integer_index_ =
+    input_mesh.has_elem_integer(extra_element_integer_name)
+      ? input_mesh.get_elem_integer_index(extra_element_integer_name)
+      : -1;
+  mesh_tally_amalgamation_valid_ =
+    extra_element_integer_index_ == -1 ? false : true;
+}
+
 // create the mesh from an input file
 LibMesh::LibMesh(const std::string& filename, double length_multiplier)
   : adaptive_(false)
@@ -3526,8 +3539,20 @@ int LibMesh::get_bin(Position r) const
 
   const auto& point_locator = pl_.at(thread_num());
 
-  const auto elem_ptr = (*point_locator)(p);
-  return elem_ptr ? get_bin_from_element(elem_ptr) : -1;
+  const auto element = (*point_locator)(p);
+  if (element) {
+    if (mesh_tally_amalgamation_valid_) {
+      if (element->get_extra_integer(extra_element_integer_index_) != -1) {
+        // that means part of a cluster. Now return the first element in the
+        // cluster
+        auto first_element = mesh_ptr()->elem_ptr(
+          element->get_extra_integer(extra_element_integer_index_));
+        return first_element ? get_bin_from_element(first_element) : -1;
+      }
+    }
+    return get_bin_from_element(element);
+  }
+  return -1;
 }
 
 int LibMesh::get_bin_from_element(const libMesh::Elem* elem) const


### PR DESCRIPTION
This code change is for doing mesh tally amalgamation in the post processing. 

Main goal is if `mesh_tally_amalgamation` is on and a bin is part of a cluster then we will only store tally in the first element in that cluster. When cardinal will access the raw tally data from openmc it will store the result in other elements in the cluster 

[details] (https://github.com/magnoxemo/cardinal/issues/13 )

@gonuke @pshriwise 
